### PR TITLE
[BE] feat: 카테고리 목록을 조회한다

### DIFF
--- a/our-memory/build.gradle
+++ b/our-memory/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.rest-assured:rest-assured:5.3.0'
+
 }
 
 tasks.named('test') {

--- a/our-memory/src/main/java/keepsake/ourmemory/api/memory/MemoryController.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/api/memory/MemoryController.java
@@ -1,0 +1,30 @@
+package keepsake.ourmemory.api.memory;
+
+import keepsake.ourmemory.api.memory.response.CategoriesResponse;
+import keepsake.ourmemory.api.memory.response.CategoryResponse;
+import keepsake.ourmemory.application.memory.MemoryService;
+import keepsake.ourmemory.application.memory.dto.CategoryDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class MemoryController {
+
+    public final MemoryService memoryService;
+
+    @GetMapping("/categories")
+    public ResponseEntity<CategoriesResponse> findCategories() {
+        List<CategoryDto> categories = memoryService.findCategories();
+        CategoriesResponse response = new CategoriesResponse(
+                categories.stream()
+                        .map(CategoryResponse::from)
+                        .toList());
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/our-memory/src/main/java/keepsake/ourmemory/api/memory/response/CategoriesResponse.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/api/memory/response/CategoriesResponse.java
@@ -1,0 +1,19 @@
+package keepsake.ourmemory.api.memory.response;
+
+import java.util.List;
+
+public class CategoriesResponse {
+
+    private List<CategoryResponse> categories;
+
+    public CategoriesResponse() {
+    }
+
+    public CategoriesResponse(List<CategoryResponse> categories) {
+        this.categories = categories;
+    }
+
+    public List<CategoryResponse> getCategories() {
+        return categories;
+    }
+}

--- a/our-memory/src/main/java/keepsake/ourmemory/api/memory/response/CategoriesResponse.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/api/memory/response/CategoriesResponse.java
@@ -6,7 +6,7 @@ public class CategoriesResponse {
 
     private List<CategoryResponse> categories;
 
-    public CategoriesResponse() {
+    protected CategoriesResponse() {
     }
 
     public CategoriesResponse(List<CategoryResponse> categories) {

--- a/our-memory/src/main/java/keepsake/ourmemory/api/memory/response/CategoryResponse.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/api/memory/response/CategoryResponse.java
@@ -1,0 +1,23 @@
+package keepsake.ourmemory.api.memory.response;
+
+import keepsake.ourmemory.application.memory.dto.CategoryDto;
+
+public class CategoryResponse {
+
+    private String name;
+
+    public CategoryResponse() {
+    }
+
+    public CategoryResponse(String name) {
+        this.name = name;
+    }
+
+    public static CategoryResponse from(CategoryDto categoryDto) {
+        return new CategoryResponse(categoryDto.getName());
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/our-memory/src/main/java/keepsake/ourmemory/api/memory/response/CategoryResponse.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/api/memory/response/CategoryResponse.java
@@ -6,7 +6,7 @@ public class CategoryResponse {
 
     private String name;
 
-    public CategoryResponse() {
+    protected CategoryResponse() {
     }
 
     public CategoryResponse(String name) {

--- a/our-memory/src/main/java/keepsake/ourmemory/application/memory/MemoryService.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/application/memory/MemoryService.java
@@ -1,0 +1,19 @@
+package keepsake.ourmemory.application.memory;
+
+import keepsake.ourmemory.application.memory.dto.CategoryDto;
+import keepsake.ourmemory.domain.memory.Category;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+public class MemoryService {
+
+    public List<CategoryDto> findCategories() {
+
+        return Arrays.stream(Category.values())
+                .map(category -> new CategoryDto(category.getName()))
+                .toList();
+    }
+}

--- a/our-memory/src/main/java/keepsake/ourmemory/application/memory/dto/CategoryDto.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/application/memory/dto/CategoryDto.java
@@ -1,0 +1,14 @@
+package keepsake.ourmemory.application.memory.dto;
+
+public class CategoryDto {
+
+    private String name;
+
+    public CategoryDto(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/our-memory/src/main/java/keepsake/ourmemory/domain/memory/Category.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/domain/memory/Category.java
@@ -1,5 +1,18 @@
 package keepsake.ourmemory.domain.memory;
 
 public enum Category {
-    RESTAURANT, CAFE, HOBBY;
+
+    RESTAURANT("음식점"),
+    CAFE("카페"),
+    HOBBY("취미");
+
+    private String name;
+
+    Category(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/our-memory/src/test/java/keepsake/ourmemory/acceptance/memory/MemoryAcceptanceTest.java
+++ b/our-memory/src/test/java/keepsake/ourmemory/acceptance/memory/MemoryAcceptanceTest.java
@@ -1,0 +1,55 @@
+package keepsake.ourmemory.acceptance.memory;
+
+import io.restassured.RestAssured;
+import keepsake.ourmemory.api.memory.response.CategoryResponse;
+import keepsake.ourmemory.domain.memory.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class MemoryAcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    void 카테고리_목록을_조회한다() {
+        // given
+        List<String> expected = Arrays.stream(Category.values())
+                .map(Category::getName)
+                .toList();
+
+        // when
+        List<CategoryResponse> response = given()
+                .contentType(JSON)
+                .when()
+                .get("/categories")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .jsonPath()
+                .getList("categories", CategoryResponse.class);
+
+        List<String> names = response.stream()
+                .map(CategoryResponse::getName)
+                .toList();
+
+        // then
+        assertThat(names).containsExactlyInAnyOrderElementsOf(expected);
+    }
+}


### PR DESCRIPTION
### 🛠️ Issue

- close #3

### ✅ Tasks
- 카테고리 목록을 조회한다

### ⏰ Time
- 2023.7.31:21:00-> 2021.7.31:22:00

### 📝 Note
- enum을 순회하고 응답하기 때문에 따로 데이터베이스에 붙지는 않습니다. 그렇기에 일단 서비스 레이어에 트랜잭션을 걸지 않았어요.
- 서비스 레이어가 레포지토리를 의존하고 있지 않기에 서비스 단위테스트는 생략했습니다.
