### PR TITLE
feat: 태그 생성, 조회, 업데이트 구현

### DIFF
--- a/our-memory/src/main/java/keepsake/ourmemory/application/repository/TagRepository.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/application/repository/TagRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
-    List<Tag> findTagsByMemberId(Long memberId);
+    List<Tag> findTagsByMemberIdAndDeletedIsFalse(Long memberId);
 }

--- a/our-memory/src/main/java/keepsake/ourmemory/application/repository/TagRepository.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/application/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package keepsake.ourmemory.application.repository;
+
+import keepsake.ourmemory.domain.tag.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/our-memory/src/main/java/keepsake/ourmemory/application/repository/TagRepository.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/application/repository/TagRepository.java
@@ -3,5 +3,9 @@ package keepsake.ourmemory.application.repository;
 import keepsake.ourmemory.domain.tag.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    List<Tag> findTagsByMemberId(Long memberId);
 }

--- a/our-memory/src/main/java/keepsake/ourmemory/application/tag/TagService.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/application/tag/TagService.java
@@ -1,6 +1,7 @@
 package keepsake.ourmemory.application.tag;
 
 import keepsake.ourmemory.application.repository.TagRepository;
+import keepsake.ourmemory.application.tag.dto.TagFindResponseDto;
 import keepsake.ourmemory.domain.tag.Tag;
 import keepsake.ourmemory.domain.tag.TagColor;
 import keepsake.ourmemory.domain.tag.TagName;
@@ -8,6 +9,8 @@ import keepsake.ourmemory.ui.tag.dto.TagCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Transactional
 @RequiredArgsConstructor
@@ -23,5 +26,13 @@ public class TagService {
 
         Tag tag = new Tag(memberId, tagName, tagColor);
         tagRepository.save(tag);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TagFindResponseDto> findTagsByMember(Long memberId) {
+        List<Tag> tags = tagRepository.findTagsByMemberId(memberId);
+        return tags.stream()
+                .map(TagFindResponseDto::from)
+                .toList();
     }
 }

--- a/our-memory/src/main/java/keepsake/ourmemory/application/tag/TagService.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/application/tag/TagService.java
@@ -1,0 +1,27 @@
+package keepsake.ourmemory.application.tag;
+
+import keepsake.ourmemory.application.repository.TagRepository;
+import keepsake.ourmemory.domain.tag.Tag;
+import keepsake.ourmemory.domain.tag.TagColor;
+import keepsake.ourmemory.domain.tag.TagName;
+import keepsake.ourmemory.ui.tag.dto.TagCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    public void createTag(TagCreateRequest request) {
+        TagName tagName = new TagName(request.getTagName());
+        TagColor tagColor = new TagColor(request.getTagColor());
+        Long memberId = request.getMemberId();
+
+        Tag tag = new Tag(memberId, tagName, tagColor);
+        tagRepository.save(tag);
+    }
+}

--- a/our-memory/src/main/java/keepsake/ourmemory/application/tag/TagService.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/application/tag/TagService.java
@@ -35,4 +35,8 @@ public class TagService {
                 .map(TagFindResponseDto::from)
                 .toList();
     }
+
+    public void deleteTagById(Long tagId) {
+        tagRepository.deleteById(tagId);
+    }
 }

--- a/our-memory/src/main/java/keepsake/ourmemory/application/tag/TagService.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/application/tag/TagService.java
@@ -30,7 +30,7 @@ public class TagService {
 
     @Transactional(readOnly = true)
     public List<TagFindResponseDto> findTagsByMember(Long memberId) {
-        List<Tag> tags = tagRepository.findTagsByMemberId(memberId);
+        List<Tag> tags = tagRepository.findTagsByMemberIdAndDeletedIsFalse(memberId);
         return tags.stream()
                 .map(TagFindResponseDto::from)
                 .toList();

--- a/our-memory/src/main/java/keepsake/ourmemory/application/tag/dto/TagFindResponseDto.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/application/tag/dto/TagFindResponseDto.java
@@ -1,0 +1,22 @@
+package keepsake.ourmemory.application.tag.dto;
+
+import keepsake.ourmemory.domain.tag.Tag;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class TagFindResponseDto {
+
+    private Long tagId;
+    private String tagName;
+    private String tagColor;
+
+    public static TagFindResponseDto from(Tag tag) {
+        return new TagFindResponseDto(
+                tag.getId(),
+                tag.getTagNameValue(),
+                tag.getTagColorValue()
+        );
+    }
+}

--- a/our-memory/src/main/java/keepsake/ourmemory/domain/tag/Tag.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/domain/tag/Tag.java
@@ -1,20 +1,17 @@
 package keepsake.ourmemory.domain.tag;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import keepsake.ourmemory.domain.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 
 import java.util.Objects;
 
 @Entity
 @Getter
+@SQLDelete(sql = "UPDATE tag SET deleted = true WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Tag extends BaseEntity {
     @Id
@@ -29,6 +26,9 @@ public class Tag extends BaseEntity {
 
     @Embedded
     private TagColor tagColor;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 
     public Tag(Long memberId, TagName tagName, TagColor tagColor) {
         this.memberId = memberId;

--- a/our-memory/src/main/java/keepsake/ourmemory/ui/tag/TagController.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/ui/tag/TagController.java
@@ -1,0 +1,23 @@
+package keepsake.ourmemory.ui.tag;
+
+import keepsake.ourmemory.application.tag.TagService;
+import keepsake.ourmemory.ui.tag.dto.TagCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class TagController {
+
+    private final TagService tagService;
+
+    @PostMapping("/tags")
+    public ResponseEntity<Void> createTag(@RequestBody TagCreateRequest request) {
+        tagService.createTag(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/our-memory/src/main/java/keepsake/ourmemory/ui/tag/TagController.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/ui/tag/TagController.java
@@ -1,13 +1,15 @@
 package keepsake.ourmemory.ui.tag;
 
 import keepsake.ourmemory.application.tag.TagService;
+import keepsake.ourmemory.application.tag.dto.TagFindResponseDto;
 import keepsake.ourmemory.ui.tag.dto.TagCreateRequest;
+import keepsake.ourmemory.ui.tag.dto.TagFindResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -19,5 +21,11 @@ public class TagController {
     public ResponseEntity<Void> createTag(@RequestBody TagCreateRequest request) {
         tagService.createTag(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/tags/members/{memberId}")
+    public ResponseEntity<TagFindResponse> findTagsByMember(@PathVariable Long memberId) {
+        List<TagFindResponseDto> tags = tagService.findTagsByMember(memberId);
+        return ResponseEntity.ok(new TagFindResponse(tags));
     }
 }

--- a/our-memory/src/main/java/keepsake/ourmemory/ui/tag/TagController.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/ui/tag/TagController.java
@@ -28,4 +28,10 @@ public class TagController {
         List<TagFindResponseDto> tags = tagService.findTagsByMember(memberId);
         return ResponseEntity.ok(new TagFindResponse(tags));
     }
+
+    @DeleteMapping("tags/{tagId}")
+    public ResponseEntity<Void> deleteTag(@PathVariable Long tagId) {
+        tagService.deleteTagById(tagId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/our-memory/src/main/java/keepsake/ourmemory/ui/tag/dto/TagCreateRequest.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/ui/tag/dto/TagCreateRequest.java
@@ -1,0 +1,15 @@
+package keepsake.ourmemory.ui.tag.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class TagCreateRequest {
+
+    private Long memberId;
+    private String tagName;
+    private String tagColor;
+}

--- a/our-memory/src/main/java/keepsake/ourmemory/ui/tag/dto/TagFindResponse.java
+++ b/our-memory/src/main/java/keepsake/ourmemory/ui/tag/dto/TagFindResponse.java
@@ -1,0 +1,18 @@
+package keepsake.ourmemory.ui.tag.dto;
+
+import keepsake.ourmemory.application.tag.dto.TagFindResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class TagFindResponse {
+
+    private List<TagFindResponseDto> tags;
+}

--- a/our-memory/src/test/java/keepsake/ourmemory/application/repository/TagRepositoryTest.java
+++ b/our-memory/src/test/java/keepsake/ourmemory/application/repository/TagRepositoryTest.java
@@ -1,0 +1,39 @@
+package keepsake.ourmemory.application.repository;
+
+import keepsake.ourmemory.domain.tag.Tag;
+import keepsake.ourmemory.domain.tag.TagColor;
+import keepsake.ourmemory.domain.tag.TagName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class TagRepositoryTest {
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Test
+    void 멤버의_태그를_조회한다() {
+        // given
+        Long memberId = 1L;
+        Tag tag1 = new Tag(memberId, new TagName("tagName1"), new TagColor("tagColor1"));
+        Tag tag2 = new Tag(memberId, new TagName("tagName2"), new TagColor("tagColor2"));
+        Tag tag3 = new Tag(2L, new TagName("tagName3"), new TagColor("tagColor3"));
+
+        tagRepository.save(tag1);
+        tagRepository.save(tag2);
+        tagRepository.save(tag3);
+
+        // when
+        List<Tag> tagsByMember = tagRepository.findTagsByMemberId(memberId);
+
+        // then
+        assertThat(tagsByMember).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
+                .containsExactlyInAnyOrder(tag1, tag2);
+    }
+}

--- a/our-memory/src/test/java/keepsake/ourmemory/application/repository/TagRepositoryTest.java
+++ b/our-memory/src/test/java/keepsake/ourmemory/application/repository/TagRepositoryTest.java
@@ -30,10 +30,28 @@ class TagRepositoryTest {
         tagRepository.save(tag3);
 
         // when
-        List<Tag> tagsByMember = tagRepository.findTagsByMemberId(memberId);
+        List<Tag> tagsByMember = tagRepository.findTagsByMemberIdAndDeletedIsFalse(memberId);
 
         // then
         assertThat(tagsByMember).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
                 .containsExactlyInAnyOrder(tag1, tag2);
+    }
+
+    @Test
+    void 멤버의_태그를_삭제한다() {
+        // given
+        Long memberId = 1L;
+        Tag tag1 = new Tag(memberId, new TagName("tagName1"), new TagColor("tagColor1"));
+        Tag tag2 = new Tag(memberId, new TagName("tagName2"), new TagColor("tagColor2"));
+
+        Tag savedTag1 = tagRepository.save(tag1);
+        Tag savedTag2 = tagRepository.save(tag2);
+
+        // when
+        tagRepository.deleteById(savedTag2.getId());
+        List<Tag> tagsByMember = tagRepository.findTagsByMemberIdAndDeletedIsFalse(memberId);
+        // then
+        assertThat(tagsByMember).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
+                .containsExactlyInAnyOrder(savedTag1);
     }
 }

--- a/our-memory/src/test/java/keepsake/ourmemory/application/tag/TagServiceTest.java
+++ b/our-memory/src/test/java/keepsake/ourmemory/application/tag/TagServiceTest.java
@@ -1,0 +1,41 @@
+package keepsake.ourmemory.application.tag;
+
+import keepsake.ourmemory.application.repository.TagRepository;
+import keepsake.ourmemory.domain.tag.Tag;
+import keepsake.ourmemory.domain.tag.TagColor;
+import keepsake.ourmemory.domain.tag.TagName;
+import keepsake.ourmemory.ui.tag.dto.TagCreateRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class TagServiceTest {
+
+    @InjectMocks
+    private TagService tagService;
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @Test
+    void 태그를_생성한다() {
+        Tag dummyTag = makeDummyTag();
+        given(tagRepository.save(any()))
+                .willReturn(dummyTag);
+
+        TagCreateRequest request = new TagCreateRequest(1L, "tagName", "tagColor");
+        assertDoesNotThrow(() -> tagService.createTag(request));
+    }
+
+    private Tag makeDummyTag() {
+        return new Tag(1L, new TagName("tagNAme"), new TagColor("tagColor"));
+    }
+
+}

--- a/our-memory/src/test/java/keepsake/ourmemory/ui/tag/TagControllerTest.java
+++ b/our-memory/src/test/java/keepsake/ourmemory/ui/tag/TagControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -34,5 +35,11 @@ class TagControllerTest {
                         .content(jsonRequest)
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().isCreated());
+    }
+
+    @Test
+    void 멤버의_태그_조회에_성공하면_200을_반환한다() throws Exception {
+        mockMvc.perform(get("/tags/members/{memberId}", 1L))
+                .andExpect(status().isOk());
     }
 }

--- a/our-memory/src/test/java/keepsake/ourmemory/ui/tag/TagControllerTest.java
+++ b/our-memory/src/test/java/keepsake/ourmemory/ui/tag/TagControllerTest.java
@@ -1,0 +1,38 @@
+package keepsake.ourmemory.ui.tag;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import keepsake.ourmemory.application.tag.TagService;
+import keepsake.ourmemory.ui.tag.dto.TagCreateRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TagController.class)
+class TagControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TagService tagService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void 태그_생성_후_201_을_반환한다() throws Exception {
+        TagCreateRequest request = new TagCreateRequest(1L, "tagName", "tagColor");
+        String jsonRequest = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(post("/tags")
+                        .content(jsonRequest)
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isCreated());
+    }
+}


### PR DESCRIPTION
### 🛠️ Issue

- close #13 

### ✅ Tasks
- 태그 생성, 조회, 업데이트 구현했습니다.
- 관련 api url을 따로 정한게 없어서 제가 임시로 정했습니다.
- 태그 조회 시 member는 memberId만 일단 받도록 했습니다.

### ⏰ Time
- from -> to

### 📝 Note
- 
